### PR TITLE
missing () on initialize method.

### DIFF
--- a/src/events.md
+++ b/src/events.md
@@ -27,7 +27,7 @@ We also add a `.ready` class to the `.reveal` element so that you can hook into 
 The `Reveal.initialize` method also returns a [Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) which resolves when the presentation is ready. The following is synonymous to adding a listener for the `ready` event:
 
 ```javascript
-Reveal.initialize.then( () => {
+Reveal.initialize().then( () => {
   // reveal.js is ready
 } )
 ```


### PR DESCRIPTION
I think this one is pretty self-explanatory. The given example will not work because it is not calling the actual ```initialize``` method.