### PR TITLE
Shortcut in Searchbar is too low

### DIFF
--- a/src/_includes/header.njk
+++ b/src/_includes/header.njk
@@ -10,7 +10,7 @@
 
     <div class="search relative mr-2 flex-grow max-w-3xl sm:mr-6">
       <input class="search-input appearance-none w-full inline-block py-1 px-4 bg-gray-300 border-2 border-gray-300 outline-none rounded-full placeholder-gray-600 text-gray-800 hover:text-gray-900 focus:border-yellow-400 focus:bg-white" placeholder="Search reveal.js..." />
-      <kbd class="search-shortcut absolute right-4 py-2 rounded-lg text-sm text-gray-600 pointer-events-none hidden sm:inline-block"><span class="search-shortcut-modifier text-lg leading-none align-middle mr-0.5">⌘</span>K</kbd>
+      <kbd class="search-shortcut absolute right-4 py-2 top-0 rounded-lg text-sm text-gray-600 pointer-events-none hidden sm:inline-block"><span class="search-shortcut-modifier text-lg leading-none align-middle mr-0.5">⌘</span>K</kbd>
       <div class="search-results overflow-hidden fixed left-4 right-4 top-100 bg-white p-2 mt-2 rounded-lg shadow-2xl text-sm lg:absolute lg:left-auto lg:right-auto lg:min-w-full" data-state="no-term"></div>
     </div>
 


### PR DESCRIPTION
Open Reveal.com in Safari to see the issue with the search shortcut.