### PR TITLE
Update link to marked advanced options

### DIFF
--- a/src/markdown.md
+++ b/src/markdown.md
@@ -164,7 +164,7 @@ We use [marked](https://github.com/chjj/marked) to parse Markdown. To customize 
 ```javascript
 Reveal.initialize({
   // Options which are passed into marked
-  // See https://marked.js.org/#/USING_ADVANCED.md#options
+  // See https://marked.js.org/using_advanced#options
   markdown: {
     smartypants: true
   }


### PR DESCRIPTION
Updates the (now invalid) link to Marked's advanced options documentation.

Also worth noting that the code example here enables `smartypants`, which the newly linked page claims is deprecated.