### PR TITLE
fix: convert tab to space in config.md

### DIFF
--- a/src/config.md
+++ b/src/config.md
@@ -64,7 +64,7 @@ Reveal.initialize({
   respondToHashChanges: true,
 
   // Enable support for jump-to-slide navigation shortcuts
-	jumpToSlide: true,
+  jumpToSlide: true,
 
   // Push each slide change to the browser history.  Implies `hash: true`
   history: false,


### PR DESCRIPTION
This PR converts an errant tab to a space, to improve rendering.

**Before:**

![image](https://github.com/reveal/revealjs.com/assets/534681/e97b7814-6b88-4009-b8b6-bbc1389d83d5)
