### PR TITLE
Updated Highlight.js demo site URL

### DIFF
--- a/src/code.md
+++ b/src/code.md
@@ -40,7 +40,7 @@ HTML will be escaped by default. To avoid this, add `data-noescape` to the `<cod
 
 ## Theming
 
-Make sure that a syntax highlight theme is included in your document. We include Monokai by default, which is distributed with the reveal.js repo at [plugin/highlight/monokai.css](https://github.com/hakimel/reveal.js/tree/master/plugin/highlight/monokai.css). A full list of available themes can be found at <https://highlightjs.org/static/demo/>.
+Make sure that a syntax highlight theme is included in your document. We include Monokai by default, which is distributed with the reveal.js repo at [plugin/highlight/monokai.css](https://github.com/hakimel/reveal.js/tree/master/plugin/highlight/monokai.css). A full list of available themes can be found at <https://highlightjs.org/demo/>.
 
 ```html
 <link rel="stylesheet" href="plugin/highlight/monokai.css" />


### PR DESCRIPTION
Fixes #66 adding a working URL for highlightjs.org demo 