### PR TITLE
Update markdown.md

### DIFF
--- a/src/markdown.md
+++ b/src/markdown.md
@@ -43,7 +43,7 @@ Note that this is sensitive to indentation (avoid mixing tabs and spaces) and li
 This functionality is powered by the built-in Markdown plugin which in turn uses [marked](https://github.com/chjj/marked) for all parsing. The Markdown plugin is included in our default presentation examples. If you want to manually add it to a new presentation here's how:
 
 ```html
-<script src="plugin/markdown/markdown.js"></script>
+<script src="dist/plugin/markdown.js"></script>
 <script>
   Reveal.initialize({
     plugins: [RevealMarkdown],


### PR DESCRIPTION
## Description

I noticed that the Markdown plugin documentation references `plugin/markdown/markdown.js`, but after running `npm run build`, the file is actually generated at `dist/plugin/markdown.js`.

I updated the path in the documentation to reflect the actual build output location, so users won't encounter 404 errors.